### PR TITLE
fixes issue with typesense not indexing

### DIFF
--- a/src/DanishAddressSeed/DanishAddressSeed.csproj
+++ b/src/DanishAddressSeed/DanishAddressSeed.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Typesense" Version="1.3.0" />
+    <PackageReference Include="Typesense" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="SchemaMigration/Scripts/create_location_schema.sql" CopyToOutputDirectory="PreserveNewest" />

--- a/src/DanishAddressSeed/Dawa/DawaClient.cs
+++ b/src/DanishAddressSeed/Dawa/DawaClient.cs
@@ -15,19 +15,16 @@ namespace DanishAddressSeed.Dawa
     {
         private readonly HttpClient _httpClient;
         private readonly ILogger<DawaClient> _logger;
-        private readonly ILocationPostgres _locationPostgres;
         private const string _dawaBasePath = "https://api.dataforsyningen.dk/replikering";
         private readonly ILocationDawaMapper _locationDawaMapper;
 
         public DawaClient(
             HttpClient httpClient,
             ILogger<DawaClient> logger,
-            ILocationPostgres locationPostgres,
             ILocationDawaMapper locationDawaMapper)
         {
             _httpClient = httpClient;
             _logger = logger;
-            _locationPostgres = locationPostgres;
             _locationDawaMapper = locationDawaMapper;
         }
 

--- a/src/DanishAddressSeed/Location/TypesenseOfficalAccessAddress.cs
+++ b/src/DanishAddressSeed/Location/TypesenseOfficalAccessAddress.cs
@@ -1,0 +1,14 @@
+namespace DanishAddressSeed.Location
+{
+    internal record TypesenseOfficalAccessAddress
+    {
+        public string Id { get; init; }
+        public string HouseNumber { get; init; }
+        public string PostDistrictCode { get; init; }
+        public string PostDistrictName { get; init; }
+        public string EastCoordinate { get; init; }
+        public string NorthCoordinate { get; init; }
+        public string TownName { get; init; }
+        public string RoadName { get; init; }
+    }
+}

--- a/src/DanishAddressSeed/Mapper/ILocationDawaMapper.cs
+++ b/src/DanishAddressSeed/Mapper/ILocationDawaMapper.cs
@@ -10,5 +10,6 @@ namespace DanishAddressSeed.Mapper
                                  string roadName,
                                  bool deleted = false);
         OfficialUnitAddress Map(DawaOfficalUnitAddress dawaAddress, bool deleted = false);
+        TypesenseOfficalAccessAddress Map(OfficialAccessAddress address);
     }
 }

--- a/src/DanishAddressSeed/Mapper/LocationDawaMapper.cs
+++ b/src/DanishAddressSeed/Mapper/LocationDawaMapper.cs
@@ -49,6 +49,21 @@ namespace DanishAddressSeed.Mapper
             };
         }
 
+        public TypesenseOfficalAccessAddress Map(OfficialAccessAddress address)
+        {
+            return new TypesenseOfficalAccessAddress
+            {
+                EastCoordinate = address.EastCoordinate.ToString(),
+                HouseNumber = address.HouseNumber,
+                Id = address.Id.ToString(),
+                NorthCoordinate = address.NorthCoordinate.ToString(),
+                PostDistrictCode = address.PostDistrictCode,
+                PostDistrictName = address.PostDistrictName,
+                RoadName = address.RoadName,
+                TownName = address.TownName
+            };
+        }
+
         private string GetStatusStringRepresentation(Status status)
         {
             switch (status)

--- a/src/DanishAddressSeed/Startup.cs
+++ b/src/DanishAddressSeed/Startup.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DanishAddressSeed.Dawa;
 using DanishAddressSeed.Location;
+using DanishAddressSeed.Mapper;
 using FluentMigrator.Runner;
 using Microsoft.Extensions.Logging;
 using Typesense;
@@ -16,6 +18,7 @@ namespace DanishAddressSeed
         private readonly IDawaClient _client;
         private readonly ILocationPostgres _locationPostgres;
         private readonly ITypesenseClient _typesenseClient;
+        private readonly ILocationDawaMapper _locationMapper;
         private const Int16 ImportBatchCount = 500;
 
         public Startup(
@@ -23,13 +26,15 @@ namespace DanishAddressSeed
             IMigrationRunner migrationRunner,
             IDawaClient client,
             ILocationPostgres locationPostgres = null,
-            ITypesenseClient typesenseClient = null)
+            ITypesenseClient typesenseClient = null,
+            ILocationDawaMapper locationMapper = null)
         {
             _logger = logger;
             _migrationRunner = migrationRunner;
             _client = client;
             _locationPostgres = locationPostgres;
             _typesenseClient = typesenseClient;
+            _locationMapper = locationMapper;
         }
 
         public async Task Start()
@@ -49,8 +54,7 @@ namespace DanishAddressSeed
             }
             else
             {
-                _logger.LogInformation(
-                    $"Getting latest changes using existing tid {lastTransactionId} and new tid {newTransactionId}");
+                _logger.LogInformation($"Getting latest changes using existing tid {lastTransactionId} and new tid {newTransactionId}");
                 await UpdateAccessAddresses(lastTransactionId, newTransactionId);
                 await UpdateUnitAddresses(lastTransactionId, newTransactionId);
             }
@@ -73,33 +77,30 @@ namespace DanishAddressSeed
                     case "update":
                         var id = await _locationPostgres.GetAccessAddressOnExternalId(changeEvent.Data.AccessAdddressExternalId);
                         if (Guid.Empty == id)
-                        {
                             throw new Exception("Id cannot be empty on an access address update");
-                        }
+
                         // We update the id here to make it match the one in the database
                         address = address with { Id = id };
+
                         await _locationPostgres.UpdateOfficalAccessAddress(address);
-                        await _typesenseClient.UpdateDocument<OfficialAccessAddress>(
-                            "Addresses", address.Id.ToString(), address);
+                        await _typesenseClient.UpdateDocument<TypesenseOfficalAccessAddress>("Addresses", address.Id.ToString(), _locationMapper.Map(address));
                         break;
                     case "insert":
-                        await _locationPostgres.InsertOfficalAccessAddresses(
-                            new List<OfficialAccessAddress> { address });
-                        await _typesenseClient.CreateDocument<OfficialAccessAddress>("Addresses", address);
+                        await _locationPostgres.InsertOfficalAccessAddresses(new List<OfficialAccessAddress> { address });
+                        await _typesenseClient.CreateDocument<TypesenseOfficalAccessAddress>("Addresses", _locationMapper.Map(address));
                         break;
                     case "delete":
                         id = await _locationPostgres.GetAccessAddressOnExternalId(changeEvent.Data.AccessAdddressExternalId);
                         if (Guid.Empty == id)
-                        {
                             throw new Exception("Id cannot be empty on an access address update");
-                        }
+
                         // We update the id here to make it match the one in the database
                         address = address with { Id = id };
 
                         // We do an update here where the deleted is set
                         await _locationPostgres.UpdateOfficalAccessAddress(address);
                         // We use the primary id from the database since we don't have it on the address object
-                        await _typesenseClient.DeleteDocument<OfficialAccessAddress>("Addresses", address.Id.ToString());
+                        await _typesenseClient.DeleteDocument<TypesenseOfficalAccessAddress>("Addresses", address.Id.ToString());
                         break;
                     default:
                         throw new Exception(
@@ -150,22 +151,25 @@ namespace DanishAddressSeed
                 {
                     count += addresses.Count;
                     _logger.LogInformation($"Imported: {count}");
-                    await _locationPostgres.InsertOfficalAccessAddresses(addresses);
-                    var typesense = await _typesenseClient.ImportDocuments<OfficialAccessAddress>(
-                        "Addresses", addresses, ImportBatchCount, ImportType.Upsert);
+                    var postgresTask = _locationPostgres.InsertOfficalAccessAddresses(addresses);
 
-                    if (typesense.Count == 0)
-                    {
-                        throw new Exception("Something bad occured");
-                    }
+                    var typesenseTask = _typesenseClient.ImportDocuments<TypesenseOfficalAccessAddress>(
+                        "Addresses",
+                        addresses.Select(x => _locationMapper.Map(x)).ToList(),
+                        ImportBatchCount,
+                        ImportType.Create);
 
+                    Task.WaitAll(postgresTask, typesenseTask);
                     addresses.Clear();
                 }
             }
 
             await _locationPostgres.InsertOfficalAccessAddresses(addresses);
-            await _typesenseClient.ImportDocuments<OfficialAccessAddress>(
-                "Addresses", addresses, addresses.Count, ImportType.Upsert);
+            await _typesenseClient.ImportDocuments<TypesenseOfficalAccessAddress>(
+                "Addresses",
+                addresses.Select(x => _locationMapper.Map(x)).ToList(),
+                addresses.Count,
+                ImportType.Create);
         }
 
         private async Task BulkInsertUnitAddresses(string newTransactionId)
@@ -190,17 +194,24 @@ namespace DanishAddressSeed
 
         private async Task SetupTypesense()
         {
+            var collections = await _typesenseClient.RetrieveCollections();
+            // We do this to make sure that the state is clean on full bulk import
+            foreach (var collection in collections)
+            {
+                await _typesenseClient.DeleteCollection(collection.Name);
+            }
+
             var schema = new Schema
             {
                 Name = "Addresses",
                 Fields = new List<Field>
                 {
                     new Field("id", "string", false),
-                    new Field("roadName", "string", false),
-                    new Field("houseNumber", "string", false),
-                    new Field("townName", "string", false),
-                    new Field("postDistrictCode", "string", false),
-                    new Field("postDistrictName", "string", false),
+                    new Field("roadName", "string", false, true),
+                    new Field("houseNumber", "string", false, true),
+                    new Field("townName", "string", false, true),
+                    new Field("postDistrictCode", "string", false, true),
+                    new Field("postDistrictName", "string", false, true),
                     new Field("eastCoordinate", "string", false),
                     new Field("northCoordinate", "string", false),
                 },


### PR DESCRIPTION
We had issues where Typesense would not index the documents, to solve this  I created an object only containing the properties needed in Typesense.

Another issue was that there were documents missing, this was because of that `town` was a `required` field instead of an `optional` field, to change this I had to upgrade the Typesense version to `1.4.0`.